### PR TITLE
Add more assert.Nil/NotNil tests

### DIFF
--- a/internal/assert/assert_test.go
+++ b/internal/assert/assert_test.go
@@ -18,11 +18,23 @@ func TestAssertions(t *testing.T) {
 
 	t.Run("nil", func(t *testing.T) {
 		Nil(t, nil, "")
-		var null *Pair
-		Nil(t, null, "")
-		NotNil(t, "foo", "")
-		NotNil(t, Pair{}, "")
+		Nil(t, (*chan int)(nil), "")
+		Nil(t, (*func())(nil), "")
+		Nil(t, (*map[int]int)(nil), "")
+		Nil(t, (*Pair)(nil), "")
+		Nil(t, (*[]int)(nil), "")
+
+		NotNil(t, make(chan int), "")
+		NotNil(t, func() {}, "")
+		NotNil(t, interface{}(1), "")
+		NotNil(t, make(map[int]int), "")
 		NotNil(t, &Pair{}, "")
+		NotNil(t, make([]int, 0), "")
+
+		NotNil(t, "foo", "")
+		NotNil(t, 0, "")
+		NotNil(t, false, "")
+		NotNil(t, Pair{}, "")
 	})
 
 	t.Run("zero", func(t *testing.T) {


### PR DESCRIPTION
I took a peek at `assert` and added a few more test cases.

`Value.IsNil()`'s documentation only mentions pointers but the implementation handles `reflect.UnsafePointer` too. I don't know if it's important enough to warrant a change in `Nil`/`NotNil` tho.