### PR TITLE
Add bad route fallback in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ func main() {
   ping := &PingServer{}
   mux := http.NewServeMux()
   mux.Handle(pingpb.NewPingHandlerReRPC(ping))
+  mux.Handle("/", rerpc.NewBadRouteHandler())
   handler := h2c.NewHandler(mux, &http2.Server{})
   http.ListenAndServe(":8081", handler)
 }


### PR DESCRIPTION
I was playing around with a poorly configured client and was hitting an
endpoint for another package. The default response returned by
http.NotFound doesn't work well with gRPC/Twirp clients. I think it's
prudent to include the fallback in the example and let expert users
remove it in case they want to do things differently.

If this is a good idea, we should update the docs to match.