### PR TITLE
Make all headers mutable

### DIFF
--- a/bad_route.go
+++ b/bad_route.go
@@ -33,7 +33,7 @@ func badRouteUnaryImpl(ctx context.Context, _ proto.Message) (proto.Message, err
 	// There's no point checking the context and sending CodeCanceled or
 	// CodeDeadlineExceeded here - it's just as fast to send the bad route error.
 	path := "???"
-	if md, ok := HandlerMeta(ctx); ok {
+	if md, ok := HandlerMetadata(ctx); ok {
 		path = md.Spec.Path
 	}
 	return nil, Wrap(CodeNotFound, newBadRouteError(path))

--- a/header_test.go
+++ b/header_test.go
@@ -161,7 +161,7 @@ func TestHeaderWrappers(t *testing.T) {
 		res:   []string{resV},
 		unres: []string{unresV},
 	}
-	h := NewMutableHeader(raw)
+	h := NewHeader(raw)
 
 	assert.Equal(t, h.Get(res), resV, "get reserved header")
 	assert.Equal(t, h.Get(unres), unresV, "get unreserved header")

--- a/interceptor_example_test.go
+++ b/interceptor_example_test.go
@@ -14,7 +14,7 @@ import (
 func ExampleCallMetadata() {
 	logger := rerpc.UnaryInterceptorFunc(func(next rerpc.Func) rerpc.Func {
 		return rerpc.Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
-			if md, ok := rerpc.CallMeta(ctx); ok {
+			if md, ok := rerpc.CallMetadata(ctx); ok {
 				fmt.Println("calling", md.Spec.Method)
 			}
 			return next(ctx, req)

--- a/metadata_test.go
+++ b/metadata_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCallMetadata(t *testing.T) {
-	_, ok := CallMeta(context.Background())
+	_, ok := CallMetadata(context.Background())
 	assert.False(t, ok, "no call metadata on bare context")
 
 	spec := &Specification{
@@ -20,7 +20,7 @@ func TestCallMetadata(t *testing.T) {
 	}
 	req, res := make(http.Header), make(http.Header)
 	ctx := NewCallContext(context.Background(), *spec, req, res)
-	md, ok := CallMeta(ctx)
+	md, ok := CallMetadata(ctx)
 	assert.True(t, ok, "get call metadata")
 	assert.Equal(t, md.Spec.ContentType, TypeJSON, "content type")
 	md.Spec.ContentType = TypeDefaultGRPC // only mutates our copy
@@ -28,12 +28,12 @@ func TestCallMetadata(t *testing.T) {
 	md.Request().Set("Foo-Bar", "baz")
 	assert.Equal(t, req, http.Header{"Foo-Bar": []string{"baz"}}, "request header after write")
 
-	_, ok = CallMeta(WithoutMeta(ctx))
+	_, ok = CallMetadata(WithoutMetadata(ctx))
 	assert.False(t, ok, "get call metadata after stripping")
 }
 
 func TestHandlerMetadata(t *testing.T) {
-	_, ok := HandlerMeta(context.Background())
+	_, ok := HandlerMetadata(context.Background())
 	assert.False(t, ok, "no handler metadata on bare context")
 
 	spec := &Specification{
@@ -44,7 +44,7 @@ func TestHandlerMetadata(t *testing.T) {
 	}
 	req, res := make(http.Header), make(http.Header)
 	ctx := NewHandlerContext(context.Background(), *spec, req, res)
-	md, ok := HandlerMeta(ctx)
+	md, ok := HandlerMetadata(ctx)
 	assert.True(t, ok, "get handler metadata")
 	assert.Equal(t, md.Spec.ContentType, TypeJSON, "content type")
 	md.Spec.ContentType = TypeDefaultGRPC // only mutates our copy
@@ -52,6 +52,6 @@ func TestHandlerMetadata(t *testing.T) {
 	md.Response().Set("Foo-Bar", "baz")
 	assert.Equal(t, res, http.Header{"Foo-Bar": []string{"baz"}}, "response header after write")
 
-	_, ok = HandlerMeta(WithoutMeta(ctx))
+	_, ok = HandlerMetadata(WithoutMetadata(ctx))
 	assert.False(t, ok, "get handler metadata after stripping")
 }

--- a/rerpc_test.go
+++ b/rerpc_test.go
@@ -708,8 +708,8 @@ type metadataIntegrationInterceptor struct {
 
 func (i *metadataIntegrationInterceptor) Wrap(next rerpc.Func) rerpc.Func {
 	return rerpc.Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
-		callMD, isCall := rerpc.CallMeta(ctx)
-		handlerMD, isHandler := rerpc.HandlerMeta(ctx)
+		callMD, isCall := rerpc.CallMetadata(ctx)
+		handlerMD, isHandler := rerpc.HandlerMetadata(ctx)
 		assert.False(
 			i.tb,
 			isCall == isHandler,

--- a/stream.go
+++ b/stream.go
@@ -209,7 +209,7 @@ func (cs *clientStream) makeRequest(prepared chan struct{}) {
 	// wait on cs.responseReady, so we can't race with them.
 	defer close(cs.responseReady)
 
-	md, ok := CallMeta(cs.ctx)
+	md, ok := CallMetadata(cs.ctx)
 	if !ok {
 		cs.setResponseError(errorf(CodeInternal, "no call metadata available on context"))
 		close(prepared)

--- a/stream.go
+++ b/stream.go
@@ -266,7 +266,7 @@ func (cs *clientStream) makeRequest(prepared chan struct{}) {
 		cs.setResponseError(wrap(code, err))
 		return
 	}
-	*md.res = NewImmutableHeader(res.Header)
+	*md.res = NewHeader(res.Header)
 
 	if res.StatusCode != http.StatusOK {
 		code := CodeUnknown


### PR DESCRIPTION
Remove `ImmutableHeader` and make all headers mutable. This lets
interceptors change the visibility of headers for code deeper in the
chain, which is particularly useful for authn/authz-related stuff. As a
nice side benefit, we remove another exported type.

Fixes #18.
