### PR TITLE
Add ErrorDetail interface

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -42,12 +42,25 @@ func TestCodeOf(t *testing.T) {
 
 func TestErrorDetails(t *testing.T) {
 	second := durationpb.New(time.Second)
+	secondErrorDetail := NewProtoErrorDetail(second)
 	detail, err := anypb.New(second)
 	assert.Nil(t, err, "create anypb.Any")
 	rerr := Errorf(CodeUnknown, "details").(*Error)
 	assert.Zero(t, rerr.Details(), "fresh error")
-	assert.Nil(t, rerr.AddDetail(second), "add detail")
-	assert.Equal(t, rerr.Details(), []*anypb.Any{detail}, "retrieve details")
-	assert.Nil(t, rerr.SetDetails(second, second), "overwrite details")
-	assert.Equal(t, rerr.Details(), []*anypb.Any{detail, detail}, "retrieve details")
+	assert.Nil(t, rerr.AddDetail(secondErrorDetail), "add detail")
+	assert.Equal(t, detailsAsAny(t, rerr.Details()), []*anypb.Any{detail}, "retrieve details")
+	assert.Nil(t, rerr.SetDetails(secondErrorDetail, secondErrorDetail), "overwrite details")
+	assert.Equal(t, detailsAsAny(t, rerr.Details()), []*anypb.Any{detail, detail}, "retrieve details")
+}
+
+// detailsAsAny is used to transform the given details into a
+// []*anypb.Any so that they can be reliably asserted in tests.
+func detailsAsAny(t *testing.T, details []interface{}) []*anypb.Any {
+	result := make([]*anypb.Any, len(details))
+	for i, detail := range details {
+		var ok bool
+		result[i], ok = detail.(*anypb.Any)
+		assert.True(t, ok, "detail should be an *anypb.Any")
+	}
+	return result
 }


### PR DESCRIPTION
In the interest of making the API a little less oriented around `proto.Message`, this explores an `ErrorDetail` interface that can only ever be implemented by the `rerpc` library (via an un-exported method).

There are some obvious warts with this approach, including:

1. The `ErrorDetail` encoding option must be explicitly defined in the `rerpc` library (i.e. users cannot define their own pluggable error detail types).
2. More allocations are required to transform to and from gRPC error details by default.
3. It's less ergonomic for clients to retrieve error details because they must manually type-assert them as a `*anypb.Any`. This gets worse when we support multiple types of details (if ever).

However, this interface makes the `Error` API less dependent on `*anypb.Any` error details, which is a gRPC-specific implementation detail. I'm not yet convinced idea just yet, but I think it's worth exploring as we audit the API as a whole.