### PR TITLE
Add a CodecProvider and refactor Stream

### DIFF
--- a/bad_route.go
+++ b/bad_route.go
@@ -18,6 +18,7 @@ func NewBadRouteHandler(opts ...HandlerOption) []*Handler {
 	}
 	h := NewHandler(
 		StreamTypeUnary,
+		nil,        // The CodecProvider is never called for this handler.
 		"", "", "", // protobuf package, service, method names
 		func(ctx context.Context, sf StreamFunc) {
 			stream := sf(ctx)

--- a/call.go
+++ b/call.go
@@ -40,6 +40,7 @@ type CallOption interface {
 // internal/ping/v1test package.
 func NewCall(
 	ctx context.Context,
+	codecProvider *CodecProvider,
 	doer Doer,
 	stype StreamType,
 	baseURL, pkg, service, method string,
@@ -82,7 +83,7 @@ func NewCall(
 	reqHeader["Te"] = teTrailersSlice
 	ctx = NewCallContext(ctx, spec, reqHeader, make(http.Header))
 	sf := StreamFunc(func(ctx context.Context) Stream {
-		return newClientStream(ctx, doer, methodURL, spec.ReadMaxBytes, cfg.EnableGzipRequest)
+		return newClientStream(ctx, codecProvider, doer, methodURL, spec.ReadMaxBytes, cfg.EnableGzipRequest)
 	})
 	return ctx, sf
 }

--- a/cmd/protoc-gen-go-rerpc/rerpc.go
+++ b/cmd/protoc-gen-go-rerpc/rerpc.go
@@ -151,6 +151,7 @@ func clientSignature(g *protogen.GeneratedFile, cname string, method *protogen.M
 func clientImplementation(g *protogen.GeneratedFile, service *protogen.Service, name string) {
 	// Client struct.
 	g.P("type ", unexport(name), " struct {")
+	g.P("codecProvider *", rerpcPackage.Ident("CodecProvider"))
 	g.P("doer ", rerpcPackage.Ident("Doer"))
 	g.P("baseURL string")
 	g.P("options []", rerpcPackage.Ident("CallOption"))
@@ -172,6 +173,7 @@ func clientImplementation(g *protogen.GeneratedFile, service *protogen.Service, 
 		", opts ...", callOption, ") ", name, " {")
 	g.P("return &", unexport(name), "{")
 	g.P("baseURL: ", stringsPackage.Ident("TrimRight"), `(baseURL, "/"),`)
+	g.P("codecProvider: ", rerpcPackage.Ident("NewCodecProvider"), "(),")
 	g.P("doer: doer,")
 	g.P("options: opts,")
 	g.P("}")
@@ -210,6 +212,7 @@ func clientMethod(g *protogen.GeneratedFile, service *protogen.Service, cname st
 	g.P("ic := ", rerpcPackage.Ident("ConfiguredCallInterceptor"), "(merged)")
 	g.P("ctx, call := ", rerpcPackage.Ident("NewCall"), "(")
 	g.P("ctx,")
+	g.P("c.codecProvider,")
 	g.P("c.doer,")
 	if isStreamingClient && isStreamingServer {
 		g.P(rerpcPackage.Ident("StreamTypeBidirectional"), ",")
@@ -414,6 +417,7 @@ func serverConstructor(g *protogen.GeneratedFile, service *protogen.Service, nam
 	}
 	g.P("func New", service.GoName, "HandlerReRPC(svc ", name, ", opts ...", rerpcPackage.Ident("HandlerOption"),
 		") []*", rerpcPackage.Ident("Handler"), " {")
+	g.P("codecProvider := ", rerpcPackage.Ident("NewCodecProvider"), "()")
 	g.P("handlers := make([]*", rerpcPackage.Ident("Handler"), ", 0, ", len(service.Methods), ")")
 	g.P("ic := ", rerpcPackage.Ident("ConfiguredHandlerInterceptor"), "(opts)")
 	g.P()
@@ -429,6 +433,7 @@ func serverConstructor(g *protogen.GeneratedFile, service *protogen.Service, nam
 			} else {
 				g.P(rerpcPackage.Ident("StreamTypeClient"), ",")
 			}
+			g.P("codecProvider,")
 			g.P(`"`, service.Desc.ParentFile().Package(), `", // protobuf package`)
 			g.P(`"`, service.Desc.Name(), `", // protobuf service`)
 			g.P(`"`, method.Desc.Name(), `", // protobuf method`)
@@ -487,6 +492,7 @@ func serverConstructor(g *protogen.GeneratedFile, service *protogen.Service, nam
 			g.P("}")
 			g.P(hname, " := ", rerpcPackage.Ident("NewHandler"), "(")
 			g.P(rerpcPackage.Ident("StreamTypeUnary"), ",")
+			g.P("codecProvider,")
 			g.P(`"`, service.Desc.ParentFile().Package(), `", // protobuf package`)
 			g.P(`"`, service.Desc.Name(), `", // protobuf service`)
 			g.P(`"`, method.Desc.Name(), `", // protobuf method`)

--- a/codec.go
+++ b/codec.go
@@ -1,0 +1,89 @@
+package rerpc
+
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// Codec defines the interface reRPC uses to encode and decode messages.
+type Codec interface {
+	Marshal(interface{}) ([]byte, error)
+	Unmarshal([]byte, interface{}) error
+}
+
+// CodecProvider provides Codecs based on the Content-Type header.
+type CodecProvider struct {
+	jsonProtobuf jsonProtobufCodec
+	protobuf     protobufCodec
+}
+
+// CodecProviderOption configures a CodecProvider.
+// There are no current CodecProviderOptions implemented.
+type CodecProviderOption interface {
+	unimplemented()
+}
+
+// NewCodecProvider returns a new CodecProvider.
+func NewCodecProvider(opts ...CodecProviderOption) *CodecProvider {
+	return &CodecProvider{
+		jsonProtobuf: jsonProtobufCodec{
+			marshaler:   protojson.MarshalOptions{UseProtoNames: true},
+			unmarshaler: protojson.UnmarshalOptions{DiscardUnknown: true},
+		},
+		protobuf: protobufCodec{},
+	}
+}
+
+// CodecForContentType returns the Codec associated with the given Content-Type
+// header value.
+func (c *CodecProvider) CodecForContentType(contentType string) (Codec, bool) {
+	switch contentType {
+	case TypeJSON:
+		return c.jsonProtobuf, true
+	case TypeDefaultGRPC, TypeProtoGRPC, TypeProtoTwirp:
+		return c.protobuf, true
+	default:
+		return nil, false
+	}
+}
+
+type jsonProtobufCodec struct {
+	marshaler   protojson.MarshalOptions
+	unmarshaler protojson.UnmarshalOptions
+}
+
+func (c jsonProtobufCodec) Marshal(value interface{}) ([]byte, error) {
+	protoMessage, ok := value.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("could not case %T to a proto.Message", value)
+	}
+	return c.marshaler.Marshal(protoMessage)
+}
+
+func (c jsonProtobufCodec) Unmarshal(data []byte, value interface{}) error {
+	protoMessage, ok := value.(proto.Message)
+	if !ok {
+		return fmt.Errorf("could not case %T to a proto.Message", value)
+	}
+	return c.unmarshaler.Unmarshal(data, protoMessage)
+}
+
+type protobufCodec struct{}
+
+func (protobufCodec) Marshal(value interface{}) ([]byte, error) {
+	protoMessage, ok := value.(proto.Message)
+	if !ok {
+		return nil, fmt.Errorf("could not case %T to a proto.Message", value)
+	}
+	return proto.Marshal(protoMessage)
+}
+
+func (protobufCodec) Unmarshal(data []byte, value interface{}) error {
+	protoMessage, ok := value.(proto.Message)
+	if !ok {
+		return fmt.Errorf("could not case %T to a proto.Message", value)
+	}
+	return proto.Unmarshal(data, protoMessage)
+}

--- a/handler.go
+++ b/handler.go
@@ -69,6 +69,7 @@ func ServeTwirp(enable bool) HandlerOption {
 // internal/ping/v1test package.
 type Handler struct {
 	stype          StreamType
+	codecProvider  *CodecProvider
 	config         handlerCfg
 	implementation func(context.Context, StreamFunc)
 }
@@ -82,6 +83,7 @@ type Handler struct {
 // won't need to deal with protobuf identifiers directly.
 func NewHandler(
 	stype StreamType,
+	codecProvider *CodecProvider,
 	pkg, service, method string,
 	implementation func(context.Context, StreamFunc),
 	opts ...HandlerOption,
@@ -99,6 +101,7 @@ func NewHandler(
 	}
 	return &Handler{
 		stype:          stype,
+		codecProvider:  codecProvider,
 		config:         cfg,
 		implementation: implementation,
 	}
@@ -265,6 +268,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	sf := StreamFunc(func(ctx context.Context) Stream {
 		return newServerStream(
 			ctx,
+			h.codecProvider,
 			w,
 			&readCloser{Reader: requestBody, Closer: r.Body},
 			spec.ContentType,

--- a/rerpc_test.go
+++ b/rerpc_test.go
@@ -538,6 +538,7 @@ func TestServerProtoGRPC(t *testing.T) {
 		callReflect := func(req *reflectionpb.ServerReflectionRequest, opts ...rerpc.CallOption) (*reflectionpb.ServerReflectionResponse, error) {
 			ctx, call := rerpc.NewCall(
 				context.Background(),
+				rerpc.NewCodecProvider(),
 				doer,
 				rerpc.StreamTypeUnary,
 				url,

--- a/short_circuit_test.go
+++ b/short_circuit_test.go
@@ -43,8 +43,8 @@ type errStream struct {
 
 var _ rerpc.Stream = (*errStream)(nil)
 
-func (s *errStream) Context() context.Context      { return s.ctx }
-func (s *errStream) Receive(_ proto.Message) error { return s.err }
-func (s *errStream) CloseReceive() error           { return s.err }
-func (s *errStream) Send(_ proto.Message) error    { return s.err }
-func (s *errStream) CloseSend(_ error) error       { return s.err }
+func (s *errStream) Context() context.Context    { return s.ctx }
+func (s *errStream) Receive(_ interface{}) error { return s.err }
+func (s *errStream) CloseReceive() error         { return s.err }
+func (s *errStream) Send(_ interface{}) error    { return s.err }
+func (s *errStream) CloseSend(_ error) error     { return s.err }


### PR DESCRIPTION
In a similar spirit to #21, this proposes a new `CodecProvider` type that could be used to support multiple encodings (not just `proto.Message`). The `CodecProvider` acts upon the `Content-Type` header value, and currently switches between Protobuf's JSON serialization (for Twirp), and the default Protobuf serialization (for gRPC). As a result of this, we can more generically represent the `Stream` interface so that it acts upon `interface{}` instead of `proto.Message`.

This is currently structured so that the `CodecProvider` is a concrete type, and must be instantiated with `rerpc.NewCodecProvider`. We might actually want to write this as an `interface` so that users can plug in their own encoding support, but they wouldn't actually be able to support a _new_ `Content-Type` in practice because `rerpc` acts specifically on the `Content-Type` values encoded by the following:

```go
// ReRPC's supported HTTP Content-Types. Servers decide whether to use the gRPC
// or Twirp protocol based on the request's Content-Type. See the protocol
// documentation at https://rerpc.github.io for more information.
const (
	TypeDefaultGRPC = "application/grpc"
	TypeProtoGRPC   = "application/grpc+proto"
	TypeProtoTwirp  = "application/protobuf"
	TypeJSON        = "application/json"
)
```

A pluggable interface would let users customize how each message is [un]marshled for each of the above `Content-Type` values, but if the user encodes something different than is what is expected between the client and server for any given `Content-Type`, then it's useless in practice.

There's a fair amount to unpack here, so let's discuss whether or not this is the right direction to take things.