### PR TITLE
Reduce protobuf coupling

### DIFF
--- a/bad_route.go
+++ b/bad_route.go
@@ -2,9 +2,6 @@ package rerpc
 
 import (
 	"context"
-
-	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/emptypb"
 )
 
 // NewBadRouteHandler always returns gRPC and Twirp's equivalent of the
@@ -22,14 +19,14 @@ func NewBadRouteHandler(opts ...HandlerOption) []*Handler {
 		func(ctx context.Context, sf StreamFunc) {
 			stream := sf(ctx)
 			_ = stream.CloseReceive()
-			_, err := wrapped(ctx, &emptypb.Empty{})
+			_, err := wrapped(ctx, nil)
 			_ = stream.CloseSend(err)
 		},
 	)
 	return []*Handler{h}
 }
 
-func badRouteUnaryImpl(ctx context.Context, _ proto.Message) (proto.Message, error) {
+func badRouteUnaryImpl(ctx context.Context, _ interface{}) (interface{}, error) {
 	// There's no point checking the context and sending CodeCanceled or
 	// CodeDeadlineExceeded here - it's just as fast to send the bad route error.
 	path := "???"

--- a/interceptor.go
+++ b/interceptor.go
@@ -2,12 +2,13 @@ package rerpc
 
 import (
 	"context"
-
-	"google.golang.org/protobuf/proto"
 )
 
 // Func is the generic signature of a unary RPC. Interceptors wrap Funcs.
-type Func func(context.Context, proto.Message) (proto.Message, error)
+//
+// The type of the request and response struct depend on the codec being used.
+// When using protobuf, they'll always be proto.Message implementations.
+type Func func(context.Context, interface{}) (interface{}, error)
 
 // StreamFunc is the generic signature of a streaming RPC. Interceptors wrap
 // StreamFuncs.

--- a/interceptor_example_test.go
+++ b/interceptor_example_test.go
@@ -5,15 +5,13 @@ import (
 	"fmt"
 	"net/http"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/rerpc/rerpc"
 	pingpb "github.com/rerpc/rerpc/internal/ping/v1test"
 )
 
 func ExampleCallMetadata() {
 	logger := rerpc.UnaryInterceptorFunc(func(next rerpc.Func) rerpc.Func {
-		return rerpc.Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
+		return rerpc.Func(func(ctx context.Context, req interface{}) (interface{}, error) {
 			if md, ok := rerpc.CallMetadata(ctx); ok {
 				fmt.Println("calling", md.Spec.Method)
 			}
@@ -36,7 +34,7 @@ func ExampleCallMetadata() {
 
 func ExampleChain() {
 	outer := rerpc.UnaryInterceptorFunc(func(next rerpc.Func) rerpc.Func {
-		return rerpc.Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
+		return rerpc.Func(func(ctx context.Context, req interface{}) (interface{}, error) {
 			fmt.Println("outer interceptor: before call")
 			res, err := next(ctx, req)
 			fmt.Println("outer interceptor: after call")
@@ -44,7 +42,7 @@ func ExampleChain() {
 		})
 	})
 	inner := rerpc.UnaryInterceptorFunc(func(next rerpc.Func) rerpc.Func {
-		return rerpc.Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
+		return rerpc.Func(func(ctx context.Context, req interface{}) (interface{}, error) {
 			fmt.Println("inner interceptor: before call")
 			res, err := next(ctx, req)
 			fmt.Println("inner interceptor: after call")

--- a/interceptor_test.go
+++ b/interceptor_test.go
@@ -6,14 +6,13 @@ import (
 	"io"
 	"testing"
 
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/rerpc/rerpc/internal/assert"
 )
 
 func assertingFunc(f func(context.Context)) Func {
-	return Func(func(ctx context.Context, _ proto.Message) (proto.Message, error) {
+	return Func(func(ctx context.Context, _ interface{}) (interface{}, error) {
 		f(ctx)
 		return &emptypb.Empty{}, nil
 	})
@@ -25,7 +24,7 @@ type loggingInterceptor struct {
 }
 
 func (i *loggingInterceptor) Wrap(next Func) Func {
-	return Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
+	return Func(func(ctx context.Context, req interface{}) (interface{}, error) {
 		io.WriteString(i.w, i.before)
 		defer func() { io.WriteString(i.w, i.after) }()
 		return next(ctx, req)

--- a/internal/crosstest/v1test/cross_rerpc.pb.go
+++ b/internal/crosstest/v1test/cross_rerpc.pb.go
@@ -10,7 +10,6 @@ import (
 	context "context"
 	errors "errors"
 	rerpc "github.com/rerpc/rerpc"
-	proto "google.golang.org/protobuf/proto"
 	strings "strings"
 )
 
@@ -78,7 +77,7 @@ func (c *crossServiceClientReRPC) Ping(ctx context.Context, req *PingRequest, op
 		"Ping",                      // protobuf method
 		merged...,
 	)
-	wrapped := rerpc.Func(func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+	wrapped := rerpc.Func(func(ctx context.Context, msg interface{}) (interface{}, error) {
 		stream := call(ctx)
 		if err := stream.Send(req); err != nil {
 			_ = stream.CloseSend(err)
@@ -105,7 +104,7 @@ func (c *crossServiceClientReRPC) Ping(ctx context.Context, req *PingRequest, op
 	}
 	typed, ok := res.(*PingResponse)
 	if !ok {
-		return nil, rerpc.Errorf(rerpc.CodeInternal, "expected response to be internal.crosstest.v1test.PingResponse, got %v", res.ProtoReflect().Descriptor().FullName())
+		return nil, rerpc.Errorf(rerpc.CodeInternal, "expected response to be internal.crosstest.v1test.PingResponse, got %T", res)
 	}
 	return typed, nil
 }
@@ -125,7 +124,7 @@ func (c *crossServiceClientReRPC) Fail(ctx context.Context, req *FailRequest, op
 		"Fail",                      // protobuf method
 		merged...,
 	)
-	wrapped := rerpc.Func(func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+	wrapped := rerpc.Func(func(ctx context.Context, msg interface{}) (interface{}, error) {
 		stream := call(ctx)
 		if err := stream.Send(req); err != nil {
 			_ = stream.CloseSend(err)
@@ -152,7 +151,7 @@ func (c *crossServiceClientReRPC) Fail(ctx context.Context, req *FailRequest, op
 	}
 	typed, ok := res.(*FailResponse)
 	if !ok {
-		return nil, rerpc.Errorf(rerpc.CodeInternal, "expected response to be internal.crosstest.v1test.FailResponse, got %v", res.ProtoReflect().Descriptor().FullName())
+		return nil, rerpc.Errorf(rerpc.CodeInternal, "expected response to be internal.crosstest.v1test.FailResponse, got %T", res)
 	}
 	return typed, nil
 }
@@ -255,13 +254,13 @@ func NewCrossServiceHandlerReRPC(svc CrossServiceReRPC, opts ...rerpc.HandlerOpt
 	handlers := make([]*rerpc.Handler, 0, 5)
 	ic := rerpc.ConfiguredHandlerInterceptor(opts)
 
-	pingFunc := rerpc.Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
+	pingFunc := rerpc.Func(func(ctx context.Context, req interface{}) (interface{}, error) {
 		typed, ok := req.(*PingRequest)
 		if !ok {
 			return nil, rerpc.Errorf(
 				rerpc.CodeInternal,
-				"can't call internal.crosstest.v1test.CrossService.Ping with a %v",
-				req.ProtoReflect().Descriptor().FullName(),
+				"can't call internal.crosstest.v1test.CrossService.Ping with a %T",
+				req,
 			)
 		}
 		return svc.Ping(ctx, typed)
@@ -312,13 +311,13 @@ func NewCrossServiceHandlerReRPC(svc CrossServiceReRPC, opts ...rerpc.HandlerOpt
 	)
 	handlers = append(handlers, ping)
 
-	failFunc := rerpc.Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
+	failFunc := rerpc.Func(func(ctx context.Context, req interface{}) (interface{}, error) {
 		typed, ok := req.(*FailRequest)
 		if !ok {
 			return nil, rerpc.Errorf(
 				rerpc.CodeInternal,
-				"can't call internal.crosstest.v1test.CrossService.Fail with a %v",
-				req.ProtoReflect().Descriptor().FullName(),
+				"can't call internal.crosstest.v1test.CrossService.Fail with a %T",
+				req,
 			)
 		}
 		return svc.Fail(ctx, typed)

--- a/internal/ping/v1test/ping_rerpc.pb.go
+++ b/internal/ping/v1test/ping_rerpc.pb.go
@@ -10,7 +10,6 @@ import (
 	context "context"
 	errors "errors"
 	rerpc "github.com/rerpc/rerpc"
-	proto "google.golang.org/protobuf/proto"
 	strings "strings"
 )
 
@@ -78,7 +77,7 @@ func (c *pingServiceClientReRPC) Ping(ctx context.Context, req *PingRequest, opt
 		"Ping",                 // protobuf method
 		merged...,
 	)
-	wrapped := rerpc.Func(func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+	wrapped := rerpc.Func(func(ctx context.Context, msg interface{}) (interface{}, error) {
 		stream := call(ctx)
 		if err := stream.Send(req); err != nil {
 			_ = stream.CloseSend(err)
@@ -105,7 +104,7 @@ func (c *pingServiceClientReRPC) Ping(ctx context.Context, req *PingRequest, opt
 	}
 	typed, ok := res.(*PingResponse)
 	if !ok {
-		return nil, rerpc.Errorf(rerpc.CodeInternal, "expected response to be internal.ping.v1test.PingResponse, got %v", res.ProtoReflect().Descriptor().FullName())
+		return nil, rerpc.Errorf(rerpc.CodeInternal, "expected response to be internal.ping.v1test.PingResponse, got %T", res)
 	}
 	return typed, nil
 }
@@ -125,7 +124,7 @@ func (c *pingServiceClientReRPC) Fail(ctx context.Context, req *FailRequest, opt
 		"Fail",                 // protobuf method
 		merged...,
 	)
-	wrapped := rerpc.Func(func(ctx context.Context, msg proto.Message) (proto.Message, error) {
+	wrapped := rerpc.Func(func(ctx context.Context, msg interface{}) (interface{}, error) {
 		stream := call(ctx)
 		if err := stream.Send(req); err != nil {
 			_ = stream.CloseSend(err)
@@ -152,7 +151,7 @@ func (c *pingServiceClientReRPC) Fail(ctx context.Context, req *FailRequest, opt
 	}
 	typed, ok := res.(*FailResponse)
 	if !ok {
-		return nil, rerpc.Errorf(rerpc.CodeInternal, "expected response to be internal.ping.v1test.FailResponse, got %v", res.ProtoReflect().Descriptor().FullName())
+		return nil, rerpc.Errorf(rerpc.CodeInternal, "expected response to be internal.ping.v1test.FailResponse, got %T", res)
 	}
 	return typed, nil
 }
@@ -255,13 +254,13 @@ func NewPingServiceHandlerReRPC(svc PingServiceReRPC, opts ...rerpc.HandlerOptio
 	handlers := make([]*rerpc.Handler, 0, 5)
 	ic := rerpc.ConfiguredHandlerInterceptor(opts)
 
-	pingFunc := rerpc.Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
+	pingFunc := rerpc.Func(func(ctx context.Context, req interface{}) (interface{}, error) {
 		typed, ok := req.(*PingRequest)
 		if !ok {
 			return nil, rerpc.Errorf(
 				rerpc.CodeInternal,
-				"can't call internal.ping.v1test.PingService.Ping with a %v",
-				req.ProtoReflect().Descriptor().FullName(),
+				"can't call internal.ping.v1test.PingService.Ping with a %T",
+				req,
 			)
 		}
 		return svc.Ping(ctx, typed)
@@ -312,13 +311,13 @@ func NewPingServiceHandlerReRPC(svc PingServiceReRPC, opts ...rerpc.HandlerOptio
 	)
 	handlers = append(handlers, ping)
 
-	failFunc := rerpc.Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
+	failFunc := rerpc.Func(func(ctx context.Context, req interface{}) (interface{}, error) {
 		typed, ok := req.(*FailRequest)
 		if !ok {
 			return nil, rerpc.Errorf(
 				rerpc.CodeInternal,
-				"can't call internal.ping.v1test.PingService.Fail with a %v",
-				req.ProtoReflect().Descriptor().FullName(),
+				"can't call internal.ping.v1test.PingService.Fail with a %T",
+				req,
 			)
 		}
 		return svc.Fail(ctx, typed)

--- a/rerpc_test.go
+++ b/rerpc_test.go
@@ -707,7 +707,7 @@ type metadataIntegrationInterceptor struct {
 }
 
 func (i *metadataIntegrationInterceptor) Wrap(next rerpc.Func) rerpc.Func {
-	return rerpc.Func(func(ctx context.Context, req proto.Message) (proto.Message, error) {
+	return rerpc.Func(func(ctx context.Context, req interface{}) (interface{}, error) {
 		callMD, isCall := rerpc.CallMetadata(ctx)
 		handlerMD, isHandler := rerpc.HandlerMetadata(ctx)
 		assert.False(

--- a/short_circuit_test.go
+++ b/short_circuit_test.go
@@ -3,8 +3,6 @@ package rerpc_test
 import (
 	"context"
 
-	"google.golang.org/protobuf/proto"
-
 	"github.com/rerpc/rerpc"
 )
 
@@ -15,7 +13,7 @@ type shortCircuit struct {
 var _ rerpc.Interceptor = (*shortCircuit)(nil)
 
 func (sc *shortCircuit) Wrap(next rerpc.Func) rerpc.Func {
-	return rerpc.Func(func(_ context.Context, _ proto.Message) (proto.Message, error) {
+	return rerpc.Func(func(_ context.Context, _ interface{}) (interface{}, error) {
 		return nil, sc.err
 	})
 }
@@ -43,8 +41,8 @@ type errStream struct {
 
 var _ rerpc.Stream = (*errStream)(nil)
 
-func (s *errStream) Context() context.Context      { return s.ctx }
-func (s *errStream) Receive(_ proto.Message) error { return s.err }
-func (s *errStream) CloseReceive() error           { return s.err }
-func (s *errStream) Send(_ proto.Message) error    { return s.err }
-func (s *errStream) CloseSend(_ error) error       { return s.err }
+func (s *errStream) Context() context.Context    { return s.ctx }
+func (s *errStream) Receive(_ interface{}) error { return s.err }
+func (s *errStream) CloseReceive() error         { return s.err }
+func (s *errStream) Send(_ interface{}) error    { return s.err }
+func (s *errStream) CloseSend(_ error) error     { return s.err }


### PR DESCRIPTION
Change the core interfaces (Stream and Func) to take the empty interface
instead of proto.Message. This opens up space to support other encodings
(e.g., flatbuffers, Thrift, msgpack) later on.

As a side benefit, it makes using Go 1.18 generics much more ergonomic.
(We may or may not actually do that.)
